### PR TITLE
Add additional configuration settings exposed on Stage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,10 @@
 *.iml
 .idea
+.project
+.settings
+.classpath
 target
 *.versionsBackup
 dependency-reduced-pom.xml
 tests.yml
+/.factorypath

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   -->
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
@@ -34,7 +34,6 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
         <version>1</version>
     </parent>
 
-    <groupId>cloud.orbit</groupId>
     <artifactId>orbit-spring</artifactId>
     <version>0.9.1-SNAPSHOT</version>
     <name>Orbit Spring</name>
@@ -50,6 +49,19 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
         <springboot.version>1.4.2.RELEASE</springboot.version>
     </properties>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <!-- Import dependency management from Spring Boot -->
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-dependencies</artifactId>
+                <version>${springboot.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>cloud.orbit</groupId>
@@ -59,7 +71,21 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-autoconfigure</artifactId>
-            <version>${springboot.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-configuration-processor</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/src/main/java/cloud/orbit/spring/OrbitActorsProperties.java
+++ b/src/main/java/cloud/orbit/spring/OrbitActorsProperties.java
@@ -31,7 +31,6 @@ package cloud.orbit.spring;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 import cloud.orbit.actors.Stage;
-import cloud.orbit.actors.extensions.ActorExtension;
 
 import java.util.List;
 
@@ -67,16 +66,16 @@ public class OrbitActorsProperties {
         return nodeName;
     }
 
-    public void setNodeName(String name) {
-        nodeName = nodeName;
+    public void setNodeName(String nodeName) {
+        this.nodeName = nodeName;
     }
 
     public Stage.StageMode getStageMode() {
         return stageMode;
     }
 
-    public void setStageMode(Stage.StageMode mode) {
-        this.stageMode = mode;
+    public void setStageMode(Stage.StageMode stageMode) {
+        this.stageMode = stageMode;
     }
 
     public Long getMessagingTimeoutInMilliseconds() {

--- a/src/main/java/cloud/orbit/spring/OrbitActorsProperties.java
+++ b/src/main/java/cloud/orbit/spring/OrbitActorsProperties.java
@@ -46,7 +46,7 @@ public class OrbitActorsProperties {
     private Long timeToLiveInSeconds;
     private List<String> stickyHeaders;
     private Integer concurrentDeactivations;
-    private Long deactivationTimeoutMillis;
+    private Long deactivationTimeoutInMilliseconds;
 
     public String getBasePackages() {
         return basePackages;
@@ -120,11 +120,11 @@ public class OrbitActorsProperties {
         this.concurrentDeactivations = concurrentDeactivations;
     }
 
-    public Long getDeactivationTimeoutMillis() {
-        return deactivationTimeoutMillis;
+    public Long getDeactivationTimeoutInMilliseconds() {
+        return deactivationTimeoutInMilliseconds;
     }
 
-    public void setDeactivationTimeoutMillis(final Long deactivationTimeoutMillis) {
-        this.deactivationTimeoutMillis = deactivationTimeoutMillis;
+    public void setDeactivationTimeoutInMilliseconds(final Long deactivationTimeoutInMilliseconds) {
+        this.deactivationTimeoutInMilliseconds = deactivationTimeoutInMilliseconds;
     }
 }

--- a/src/main/java/cloud/orbit/spring/OrbitActorsProperties.java
+++ b/src/main/java/cloud/orbit/spring/OrbitActorsProperties.java
@@ -41,7 +41,6 @@ public class OrbitActorsProperties {
     private String clusterName;
     private String nodeName;
     private Stage.StageMode stageMode;
-    private List<ActorExtension> extensions;
     private Long messagingTimeoutInMilliseconds;
     private Long timeToLiveInSeconds;
     private List<String> stickyHeaders;
@@ -78,14 +77,6 @@ public class OrbitActorsProperties {
 
     public void setStageMode(Stage.StageMode mode) {
         this.stageMode = mode;
-    }
-
-    public List<ActorExtension> getExtensions() {
-        return extensions;
-    }
-
-    public void setExtensions(final List<ActorExtension> extensions) {
-        this.extensions = extensions;
     }
 
     public Long getMessagingTimeoutInMilliseconds() {

--- a/src/main/java/cloud/orbit/spring/OrbitActorsProperties.java
+++ b/src/main/java/cloud/orbit/spring/OrbitActorsProperties.java
@@ -28,19 +28,33 @@
 
 package cloud.orbit.spring;
 
-import cloud.orbit.actors.Stage;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import cloud.orbit.actors.Stage;
+import cloud.orbit.actors.extensions.ActorExtension;
 
 import java.util.List;
 
 @ConfigurationProperties(prefix = "orbit.actors")
 public class OrbitActorsProperties {
+    private String basePackages;
     private String clusterName;
     private String nodeName;
     private Stage.StageMode stageMode;
+    private List<ActorExtension> extensions;
     private Long messagingTimeoutInMilliseconds;
     private Long timeToLiveInSeconds;
     private List<String> stickyHeaders;
+    private Integer concurrentDeactivations;
+    private Long deactivationTimeoutMillis;
+
+    public String getBasePackages() {
+        return basePackages;
+    }
+
+    public void setBasePackages(final String basePackages) {
+        this.basePackages = basePackages;
+    }
 
     public String getClusterName() {
         return clusterName;
@@ -66,6 +80,14 @@ public class OrbitActorsProperties {
         this.stageMode = mode;
     }
 
+    public List<ActorExtension> getExtensions() {
+        return extensions;
+    }
+
+    public void setExtensions(final List<ActorExtension> extensions) {
+        this.extensions = extensions;
+    }
+
     public Long getMessagingTimeoutInMilliseconds() {
         return messagingTimeoutInMilliseconds;
     }
@@ -88,5 +110,21 @@ public class OrbitActorsProperties {
 
     public void setStickyHeaders(List<String> headers) {
         this.stickyHeaders = headers;
+    }
+
+    public Integer getConcurrentDeactivations() {
+        return concurrentDeactivations;
+    }
+
+    public void setConcurrentDeactivations(final Integer concurrentDeactivations) {
+        this.concurrentDeactivations = concurrentDeactivations;
+    }
+
+    public Long getDeactivationTimeoutMillis() {
+        return deactivationTimeoutMillis;
+    }
+
+    public void setDeactivationTimeoutMillis(final Long deactivationTimeoutMillis) {
+        this.deactivationTimeoutMillis = deactivationTimeoutMillis;
     }
 }

--- a/src/main/java/cloud/orbit/spring/OrbitSpringConfiguration.java
+++ b/src/main/java/cloud/orbit/spring/OrbitSpringConfiguration.java
@@ -35,10 +35,8 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 import cloud.orbit.actors.Stage;
-import cloud.orbit.actors.extensions.ActorExtension;
 import cloud.orbit.actors.runtime.Messaging;
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
@@ -53,7 +51,8 @@ public class OrbitSpringConfiguration {
 
     @Bean
     public Stage stage(OrbitActorsProperties properties) {
-        Stage.Builder stageBuilder = new Stage.Builder();
+        Stage.Builder stageBuilder = new Stage.Builder()
+                .extensions(new SpringLifetimeExtension(factory));
 
         if (properties.getBasePackages() != null) {
             stageBuilder.basePackages(properties.getBasePackages());
@@ -71,12 +70,6 @@ public class OrbitSpringConfiguration {
         {
             stageBuilder.mode(properties.getStageMode());
         }
-
-        List<ActorExtension> actorExtensions = Arrays.asList(new SpringLifetimeExtension(factory));
-        if (properties.getExtensions() != null) {
-            actorExtensions.addAll(properties.getExtensions());
-        }
-        stageBuilder.extensions(actorExtensions.toArray(new ActorExtension[actorExtensions.size()]));
 
         if (properties.getTimeToLiveInSeconds() != null) {
             stageBuilder.actorTTL(properties.getTimeToLiveInSeconds(), TimeUnit.SECONDS);

--- a/src/main/java/cloud/orbit/spring/OrbitSpringConfiguration.java
+++ b/src/main/java/cloud/orbit/spring/OrbitSpringConfiguration.java
@@ -96,8 +96,8 @@ public class OrbitSpringConfiguration {
             stageBuilder.concurrentDeactivations(properties.getConcurrentDeactivations());
         }
 
-        if (properties.getDeactivationTimeoutMillis() != null) {
-            stageBuilder.deactivationTimeout(properties.getDeactivationTimeoutMillis(), TimeUnit.MILLISECONDS);
+        if (properties.getDeactivationTimeoutInMilliseconds() != null) {
+            stageBuilder.deactivationTimeout(properties.getDeactivationTimeoutInMilliseconds(), TimeUnit.MILLISECONDS);
         }
 
         Stage stage = stageBuilder.build();

--- a/src/main/java/cloud/orbit/spring/OrbitSpringConfiguration.java
+++ b/src/main/java/cloud/orbit/spring/OrbitSpringConfiguration.java
@@ -35,6 +35,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 import cloud.orbit.actors.Stage;
+import cloud.orbit.actors.extensions.ActorExtension;
 import cloud.orbit.actors.runtime.Messaging;
 
 import java.util.List;
@@ -43,16 +44,18 @@ import java.util.concurrent.TimeUnit;
 @Configuration
 @EnableConfigurationProperties(OrbitActorsProperties.class)
 public class OrbitSpringConfiguration {
-    @Autowired
-    AutowireCapableBeanFactory factory;
-
     @Autowired(required = false)
-    List<OrbitSpringConfigurationAddon> configAddons;
+    private List<OrbitSpringConfigurationAddon> configAddons;
 
     @Bean
-    public Stage stage(OrbitActorsProperties properties) {
+    public ActorExtension springLifecycleExtension(AutowireCapableBeanFactory factory) {
+      return new SpringLifetimeExtension(factory);
+    }
+
+    @Bean
+    public Stage stage(OrbitActorsProperties properties, List<ActorExtension> actorExtensions) {
         Stage.Builder stageBuilder = new Stage.Builder()
-                .extensions(new SpringLifetimeExtension(factory));
+                .extensions(actorExtensions.toArray(new ActorExtension[actorExtensions.size()]));
 
         if (properties.getBasePackages() != null) {
             stageBuilder.basePackages(properties.getBasePackages());
@@ -66,8 +69,7 @@ public class OrbitSpringConfiguration {
             stageBuilder.nodeName(properties.getNodeName());
         }
 
-        if (properties.getStageMode() != null)
-        {
+        if (properties.getStageMode() != null) {
             stageBuilder.mode(properties.getStageMode());
         }
 

--- a/src/main/java/cloud/orbit/spring/SpringLifetimeExtension.java
+++ b/src/main/java/cloud/orbit/spring/SpringLifetimeExtension.java
@@ -44,13 +44,12 @@ class SpringLifetimeExtension implements LifetimeExtension {
     // Provides constructor injection for actors
     @Override
     public <T> T newInstance(Class<T> concreteClass) {
-        T instance = (T)beanFactory.createBean(concreteClass);
-        return instance;
+        return beanFactory.createBean(concreteClass);
     }
 
     // Provides property injection for actors
     @Override
-    public Task preActivation(AbstractActor actor) {
+    public Task<Void> preActivation(AbstractActor<?> actor) {
         beanFactory.autowireBeanProperties(actor, AutowireCapableBeanFactory.AUTOWIRE_BY_TYPE ,false);
         return Task.done();
     }

--- a/src/test/java/cloud/orbit/spring/OrbitSpringConfigurationTest.java
+++ b/src/test/java/cloud/orbit/spring/OrbitSpringConfigurationTest.java
@@ -1,0 +1,72 @@
+/*
+ Copyright (C) 2017 Electronic Arts Inc.  All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+
+ 1.  Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+ 2.  Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+ 3.  Neither the name of Electronic Arts, Inc. ("EA") nor the names of
+     its contributors may be used to endorse or promote products derived
+     from this software without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY ELECTRONIC ARTS AND ITS CONTRIBUTORS "AS IS" AND ANY
+ EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL ELECTRONIC ARTS OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package cloud.orbit.spring;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.context.ApplicationContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import cloud.orbit.actors.Stage;
+import cloud.orbit.actors.extensions.ActorExtension;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertTrue;
+
+/*
+ * Very simple (poor) tests to validate that the SpringLifecycleExtension is being properly bound to the Stage
+ */
+@RunWith(SpringRunner.class)
+@SpringBootTest(webEnvironment = WebEnvironment.NONE)
+@ContextConfiguration(classes = OrbitSpringConfiguration.class)
+public class OrbitSpringConfigurationTest {
+    @Autowired
+    private ApplicationContext applicationContext;
+
+    @Test
+    public void loadSpringLifecycleExtensions() throws Exception {
+        Map<String, ActorExtension> actorExtensionBeans = applicationContext.getBeansOfType(ActorExtension.class);
+        assertTrue(actorExtensionBeans.keySet().contains("springLifecycleExtension"));
+    }
+
+    @Test
+    public void validateStageHasSpringLifecycleExtension() throws Exception {
+        Stage stage = applicationContext.getBean(Stage.class);
+        List<ActorExtension> actorExtensions = stage.getAllExtensions(ActorExtension.class);
+        long count = actorExtensions.stream().filter(actorExtension -> actorExtension.getClass()
+                .isAssignableFrom(SpringLifetimeExtension.class)).count();
+        assertTrue(count == 1);
+    }
+}


### PR DESCRIPTION
The `OrbitActorsProperties` class was missing some configuration settings that are annotated on the `Stage` class and were once available to configure externally using the old hk2 container.

I added these properties:
* orbit.actors.basePackages
* orbit.actors.extensions
* orbit.actors.concurrentDeactivations
* orbit.actors.deactivationTimeoutMillis

NOTE: There are two additional properties that are annotated on the `Stage` class that I was NOT able to add because they are not exposed on `Stage.Builder`:
* orbit.actors.pulseInterval
* orbit.actors.executionPoolSize