### PR TITLE
ActorInfoContributorLifetimeExtension for Spring Boot Actuator

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,61 @@ is running and the local node is alive. The health details are listed under the 
 }
 ```
 
+### Info Contributor
+
+The
+[ActorInfoContributorLifetimeExtension](https://github.com/orbit/orbit-spring/blob/master/src/main/java/cloud/orbit/spring/actuate/ActorInfoContributorLifetimeExtension.java)
+is an
+[InfoContributor](https://github.com/spring-projects/spring-boot/blob/v1.5.4.RELEASE/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/info/InfoContributor.java)
+which aggregates info from
+[Actor](https://github.com/orbit/orbit/blob/master/actors/core/src/main/java/cloud/orbit/actors/Actor.java)
+implementation classes that implement the InfoContributor interface. The actors' info is listed under the key "actors"
+in the
+[info endpoint](https://docs.spring.io/spring-boot/docs/current/reference/html/production-ready-endpoints.html#production-ready-application-info).
+
+Suppose we have an actor defined as follows:
+
+```java
+public class MyActorImpl extends AbstractActor implements MyActor, InfoContributor {
+    @Override
+    public void contribute(final Info.Builder builder) {
+        builder.withDetail("status", state().getStatus());
+    }
+    ...
+}
+```
+
+If we activate two instances with identities "a" and "b", we might see this response from the `info` endpoint:
+
+```json
+{
+    "actors": {
+        "MyActor": {
+            "a": {
+                "status": {
+                    "foo": false,
+                    "bar": 0
+                }
+            },
+            "b": {
+                "status": {
+                    "foo": true,
+                    "bar": 42
+                }
+            }
+        }
+    }
+}
+```
+
+By default, actor info is grouped primarily by the actor interface, and secondarily by the actor identity. This is
+customizable by setting the properties:
+
+```yaml
+management.info.actors.group.primary: NONE | INTERFACE | IDENTITY
+management.info.actors.group.secondary: NONE | INTERFACE | IDENTITY
+```
+
 Developer & License
 ======
 This project was developed by [Electronic Arts](http://www.ea.com) and is licensed under the [BSD 3-Clause License](LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -79,6 +79,11 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-configuration-processor</artifactId>
             <optional>true</optional>
         </dependency>
@@ -93,8 +98,19 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>19.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/cloud/orbit/spring/actuate/ActorInfoContributorConfiguration.java
+++ b/src/main/java/cloud/orbit/spring/actuate/ActorInfoContributorConfiguration.java
@@ -35,6 +35,7 @@ import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -47,25 +48,59 @@ import java.util.concurrent.ExecutorService;
 @ConditionalOnClass(InfoContributor.class)
 @ConditionalOnEnabledInfoContributor("actors")
 @AutoConfigureAfter(OrbitSpringConfiguration.class)
+@EnableConfigurationProperties(ActorInfoContributorConfiguration.GroupProperties.class)
 public class ActorInfoContributorConfiguration
 {
     @Bean
-    @ConditionalOnMissingBean(ActorInfoDetailsContainer.GroupProperties.class)
-    @ConfigurationProperties(prefix = "management.info.actors.group")
-    public ActorInfoDetailsContainer.GroupProperties actorInfoContainerProperties()
-    {
-        return new ActorInfoDetailsContainer.GroupProperties();
-    }
-
-    @Bean
     @ConditionalOnMissingBean(ActorInfoContributorLifetimeExtension.class)
     public ActorInfoContributorLifetimeExtension actorInfoContributorLifetimeExtension(
-            final ActorInfoDetailsContainer.GroupProperties groupProperties,
-            @Qualifier("stageExecutorService") final ExecutorService stageExecutorService)
+            @Qualifier("stageExecutorService") final ExecutorService stageExecutorService,
+            final GroupProperties groupProperties)
     {
         return new ActorInfoContributorLifetimeExtension(
                 RemoteReference::getInterfaceClass,
                 new ActorInfoDetailsContainer(groupProperties),
                 stageExecutorService);
+    }
+
+    @ConfigurationProperties(prefix = "management.info.actors.group")
+    static class GroupProperties
+    {
+        private GroupType primary = GroupType.INTERFACE;
+        private GroupType secondary = GroupType.IDENTITY;
+
+        public GroupType getPrimary()
+        {
+            return primary;
+        }
+
+        public GroupType getSecondary()
+        {
+            return secondary;
+        }
+
+        public void setPrimary(final GroupType primary)
+        {
+            this.primary = primary;
+        }
+
+        public void setSecondary(final GroupType secondary)
+        {
+            this.secondary = secondary;
+        }
+
+        @Override
+        public String toString()
+        {
+            return "GroupProperties{" +
+                    "primary=" + primary +
+                    ", secondary=" + secondary +
+                    '}';
+        }
+
+        enum GroupType
+        {
+            NONE, INTERFACE, IDENTITY
+        }
     }
 }

--- a/src/main/java/cloud/orbit/spring/actuate/ActorInfoContributorConfiguration.java
+++ b/src/main/java/cloud/orbit/spring/actuate/ActorInfoContributorConfiguration.java
@@ -28,8 +28,10 @@
 
 package cloud.orbit.spring.actuate;
 
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.actuate.autoconfigure.ConditionalOnEnabledInfoContributor;
 import org.springframework.boot.actuate.info.InfoContributor;
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -37,10 +39,14 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 import cloud.orbit.actors.runtime.RemoteReference;
+import cloud.orbit.spring.OrbitSpringConfiguration;
+
+import java.util.concurrent.ExecutorService;
 
 @Configuration
 @ConditionalOnClass(InfoContributor.class)
 @ConditionalOnEnabledInfoContributor("actors")
+@AutoConfigureAfter(OrbitSpringConfiguration.class)
 public class ActorInfoContributorConfiguration
 {
     @Bean
@@ -54,10 +60,12 @@ public class ActorInfoContributorConfiguration
     @Bean
     @ConditionalOnMissingBean(ActorInfoContributorLifetimeExtension.class)
     public ActorInfoContributorLifetimeExtension actorInfoContributorLifetimeExtension(
-            final ActorInfoDetailsContainer.GroupProperties groupProperties)
+            final ActorInfoDetailsContainer.GroupProperties groupProperties,
+            @Qualifier("stageExecutorService") final ExecutorService stageExecutorService)
     {
         return new ActorInfoContributorLifetimeExtension(
                 RemoteReference::getInterfaceClass,
-                new ActorInfoDetailsContainer(groupProperties));
+                new ActorInfoDetailsContainer(groupProperties),
+                stageExecutorService);
     }
 }

--- a/src/main/java/cloud/orbit/spring/actuate/ActorInfoContributorConfiguration.java
+++ b/src/main/java/cloud/orbit/spring/actuate/ActorInfoContributorConfiguration.java
@@ -1,0 +1,51 @@
+/*
+ Copyright (C) 2017 Electronic Arts Inc.  All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+
+ 1.  Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+ 2.  Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+ 3.  Neither the name of Electronic Arts, Inc. ("EA") nor the names of
+     its contributors may be used to endorse or promote products derived
+     from this software without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY ELECTRONIC ARTS AND ITS CONTRIBUTORS "AS IS" AND ANY
+ EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL ELECTRONIC ARTS OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package cloud.orbit.spring.actuate;
+
+import org.springframework.boot.actuate.autoconfigure.ConditionalOnEnabledInfoContributor;
+import org.springframework.boot.actuate.info.InfoContributor;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import cloud.orbit.actors.runtime.RemoteReference;
+
+@Configuration
+@ConditionalOnClass(InfoContributor.class)
+@ConditionalOnEnabledInfoContributor("actors")
+public class ActorInfoContributorConfiguration
+{
+    @Bean
+    @ConditionalOnMissingBean(ActorInfoContributorLifetimeExtension.class)
+    public ActorInfoContributorLifetimeExtension actorInfoContributorLifetimeExtension()
+    {
+        return new ActorInfoContributorLifetimeExtension(RemoteReference::getInterfaceClass);
+    }
+}

--- a/src/main/java/cloud/orbit/spring/actuate/ActorInfoContributorLifetimeExtension.java
+++ b/src/main/java/cloud/orbit/spring/actuate/ActorInfoContributorLifetimeExtension.java
@@ -1,0 +1,140 @@
+/*
+ Copyright (C) 2017 Electronic Arts Inc.  All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+
+ 1.  Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+ 2.  Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+ 3.  Neither the name of Electronic Arts, Inc. ("EA") nor the names of
+     its contributors may be used to endorse or promote products derived
+     from this software without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY ELECTRONIC ARTS AND ITS CONTRIBUTORS "AS IS" AND ANY
+ EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL ELECTRONIC ARTS OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package cloud.orbit.spring.actuate;
+
+import org.springframework.boot.actuate.info.Info;
+import org.springframework.boot.actuate.info.InfoContributor;
+
+import cloud.orbit.actors.Actor;
+import cloud.orbit.actors.extensions.LifetimeExtension;
+import cloud.orbit.actors.runtime.AbstractActor;
+import cloud.orbit.concurrent.Task;
+
+import java.lang.ref.WeakReference;
+import java.util.*;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+public class ActorInfoContributorLifetimeExtension implements LifetimeExtension, InfoContributor
+{
+    private final Function<AbstractActor, Class> actorTypeResolver;
+
+    private Set<ActorInfoContributorReference> actorInfoContributorReferences = new HashSet<>();
+
+    ActorInfoContributorLifetimeExtension(final Function<AbstractActor, Class> actorTypeResolver)
+    {
+        this.actorTypeResolver = actorTypeResolver;
+    }
+
+    @Override
+    public Task<?> preActivation(final AbstractActor<?> actor)
+    {
+        return doIfInfoContributor(actor, actorInfoContributorReferences::add);
+    }
+
+    @Override
+    public Task<?> preDeactivation(final AbstractActor<?> actor)
+    {
+        return doIfInfoContributor(actor, actorInfoContributorReferences::remove);
+    }
+
+    private Task<?> doIfInfoContributor(final AbstractActor<?> actor,
+                                        final Consumer<ActorInfoContributorReference> synchronizedAction)
+    {
+        if (actor instanceof InfoContributor)
+        {
+            ActorInfoContributorReference actorInfoContributorReference = new ActorInfoContributorReference(actor);
+            synchronized(this)
+            {
+                synchronizedAction.accept(actorInfoContributorReference);
+            }
+        }
+        return Task.done();
+    }
+
+    @Override
+    public void contribute(final Info.Builder builder)
+    {
+        createInfoObjectAndRemoveExpiredReferences()
+                .ifPresent(actorInfoObject -> builder.withDetail("actors", actorInfoObject));
+    }
+
+    private synchronized Optional<?> createInfoObjectAndRemoveExpiredReferences()
+    {
+        Map<String, Map<String, Object>> actorInfoObject = new HashMap<>();
+        for (Iterator<ActorInfoContributorReference> it = actorInfoContributorReferences.iterator(); it.hasNext(); )
+        {
+            ActorInfoContributorReference actor = it.next();
+            InfoContributor contributor = actor.reference.get();
+            if (contributor == null)
+            {
+                it.remove();
+            }
+            else
+            {
+                final Info.Builder builder = new Info.Builder();
+                contributor.contribute(builder);
+                actorInfoObject.putIfAbsent(actor.name, new HashMap<>());
+                actorInfoObject.get(actor.name).put(actor.identity, builder.build().getDetails());
+            }
+        }
+        return actorInfoObject.isEmpty() ? Optional.empty() : Optional.of(actorInfoObject);
+    }
+
+    private class ActorInfoContributorReference
+    {
+        private final WeakReference<InfoContributor> reference;
+        private final String name;
+        private final String identity;
+
+        private ActorInfoContributorReference(final AbstractActor<?> actor)
+        {
+            reference = new WeakReference<>((InfoContributor) actor);
+            name = actorTypeResolver.apply(actor).getSimpleName();
+            identity = ((Actor) actor).getIdentity();
+        }
+
+        @Override
+        public boolean equals(final Object o)
+        {
+            if (o == null || getClass() != o.getClass())
+            {
+                return false;
+            }
+            final ActorInfoContributorReference that = (ActorInfoContributorReference) o;
+            return name.equals(that.name) && identity.equals(that.identity);
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return name.hashCode() ^ identity.hashCode();
+        }
+    }
+}

--- a/src/main/java/cloud/orbit/spring/actuate/ActorInfoDetailsContainer.java
+++ b/src/main/java/cloud/orbit/spring/actuate/ActorInfoDetailsContainer.java
@@ -30,11 +30,7 @@ package cloud.orbit.spring.actuate;
 
 import org.springframework.boot.actuate.info.Info;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
@@ -63,7 +59,7 @@ class ActorInfoDetailsContainer
         return Optional.empty();
     }
 
-    void mergeDetailsFrom(ActorInfoContributorReference actorInfoContributorReference)
+    synchronized void mergeDetailsFrom(ActorInfoContributorReference actorInfoContributorReference)
     {
         Info.Builder builder = new Info.Builder();
         actorInfoContributorReference.getInfoContributor().contribute(builder);
@@ -78,9 +74,11 @@ class ActorInfoDetailsContainer
         whereToPutDetails.putAll(builder.build().getDetails());
     }
 
-    Map<String, Object> getDetails()
+    synchronized Map<String, Object> getDetailsSnapshot()
     {
-        return details;
+        HashMap<String, Object> detailsCopy = new HashMap<>(details);
+        details.clear();
+        return detailsCopy;
     }
 
     @SuppressWarnings({ "WeakerAccess", "unused" }) // public setters needed for Spring to inject properties

--- a/src/main/java/cloud/orbit/spring/actuate/ActorInfoDetailsContainer.java
+++ b/src/main/java/cloud/orbit/spring/actuate/ActorInfoDetailsContainer.java
@@ -39,20 +39,20 @@ class ActorInfoDetailsContainer
     private final List<Function<ActorInfoContributorReference, String>> detailLevelHandlers = new ArrayList<>();
     private final Map<String, Object> details = new HashMap<>();
 
-    ActorInfoDetailsContainer(GroupProperties groupProperties)
+    ActorInfoDetailsContainer(ActorInfoContributorConfiguration.GroupProperties groupProperties)
     {
-        Stream.of(groupProperties.primary, groupProperties.secondary)
+        Stream.of(groupProperties.getPrimary(), groupProperties.getSecondary())
                 .map(this::deriveHandlerFromGroupType)
                 .forEach(handler -> handler.ifPresent(detailLevelHandlers::add));
     }
 
     private Optional<Function<ActorInfoContributorReference, String>> deriveHandlerFromGroupType(
-            final GroupProperties.GroupType groupType) {
-        if (groupType == GroupProperties.GroupType.IDENTITY)
+            final ActorInfoContributorConfiguration.GroupProperties.GroupType groupType) {
+        if (groupType == ActorInfoContributorConfiguration.GroupProperties.GroupType.IDENTITY)
         {
             return Optional.of(ActorInfoContributorReference::getIdentity);
         }
-        if (groupType == GroupProperties.GroupType.INTERFACE)
+        if (groupType == ActorInfoContributorConfiguration.GroupProperties.GroupType.INTERFACE)
         {
             return Optional.of(ActorInfoContributorReference::getName);
         }
@@ -79,36 +79,5 @@ class ActorInfoDetailsContainer
         HashMap<String, Object> detailsCopy = new HashMap<>(details);
         details.clear();
         return detailsCopy;
-    }
-
-    @SuppressWarnings({ "WeakerAccess", "unused" }) // public setters needed for Spring to inject properties
-    static class GroupProperties
-    {
-        private GroupType primary = GroupType.INTERFACE;
-        private GroupType secondary = GroupType.IDENTITY;
-
-        public void setPrimary(final GroupType primary)
-        {
-            this.primary = primary;
-        }
-
-        public void setSecondary(final GroupType secondary)
-        {
-            this.secondary = secondary;
-        }
-
-        @Override
-        public String toString()
-        {
-            return "GroupProperties{" +
-                    "primary=" + primary +
-                    ", secondary=" + secondary +
-                    '}';
-        }
-
-        enum GroupType
-        {
-            NONE, INTERFACE, IDENTITY
-        }
     }
 }

--- a/src/main/java/cloud/orbit/spring/actuate/ActorInfoDetailsContainer.java
+++ b/src/main/java/cloud/orbit/spring/actuate/ActorInfoDetailsContainer.java
@@ -1,0 +1,116 @@
+/*
+ Copyright (C) 2017 Electronic Arts Inc.  All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+
+ 1.  Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+ 2.  Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+ 3.  Neither the name of Electronic Arts, Inc. ("EA") nor the names of
+     its contributors may be used to endorse or promote products derived
+     from this software without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY ELECTRONIC ARTS AND ITS CONTRIBUTORS "AS IS" AND ANY
+ EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL ELECTRONIC ARTS OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package cloud.orbit.spring.actuate;
+
+import org.springframework.boot.actuate.info.Info;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+class ActorInfoDetailsContainer
+{
+    private final List<Function<ActorInfoContributorReference, String>> detailLevelHandlers = new ArrayList<>();
+    private final Map<String, Object> details = new HashMap<>();
+
+    ActorInfoDetailsContainer(GroupProperties groupProperties)
+    {
+        Stream.of(groupProperties.primary, groupProperties.secondary)
+                .map(this::deriveHandlerFromGroupType)
+                .forEach(handler -> handler.ifPresent(detailLevelHandlers::add));
+    }
+
+    private Optional<Function<ActorInfoContributorReference, String>> deriveHandlerFromGroupType(
+            final GroupProperties.GroupType groupType) {
+        if (groupType == GroupProperties.GroupType.IDENTITY)
+        {
+            return Optional.of(ActorInfoContributorReference::getIdentity);
+        }
+        if (groupType == GroupProperties.GroupType.INTERFACE)
+        {
+            return Optional.of(ActorInfoContributorReference::getName);
+        }
+        return Optional.empty();
+    }
+
+    void mergeDetailsFrom(ActorInfoContributorReference actorInfoContributorReference)
+    {
+        Info.Builder builder = new Info.Builder();
+        actorInfoContributorReference.getInfoContributor().contribute(builder);
+        Map<String, Object> whereToPutDetails = details;
+        for (Function<ActorInfoContributorReference, String> handler: detailLevelHandlers)
+        {
+            String key = handler.apply(actorInfoContributorReference);
+            whereToPutDetails.putIfAbsent(key, new HashMap<String, Object>());
+            //noinspection unchecked
+            whereToPutDetails = (Map<String, Object>) whereToPutDetails.get(key);
+        }
+        whereToPutDetails.putAll(builder.build().getDetails());
+    }
+
+    Map<String, Object> getDetails()
+    {
+        return details;
+    }
+
+    @SuppressWarnings({ "WeakerAccess", "unused" }) // public setters needed for Spring to inject properties
+    static class GroupProperties
+    {
+        private GroupType primary = GroupType.INTERFACE;
+        private GroupType secondary = GroupType.IDENTITY;
+
+        public void setPrimary(final GroupType primary)
+        {
+            this.primary = primary;
+        }
+
+        public void setSecondary(final GroupType secondary)
+        {
+            this.secondary = secondary;
+        }
+
+        @Override
+        public String toString()
+        {
+            return "GroupProperties{" +
+                    "primary=" + primary +
+                    ", secondary=" + secondary +
+                    '}';
+        }
+
+        enum GroupType
+        {
+            NONE, INTERFACE, IDENTITY
+        }
+    }
+}

--- a/src/main/java/cloud/orbit/spring/actuate/AsyncLifetimeExtension.java
+++ b/src/main/java/cloud/orbit/spring/actuate/AsyncLifetimeExtension.java
@@ -1,0 +1,106 @@
+/*
+ Copyright (C) 2017 Electronic Arts Inc.  All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+
+ 1.  Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+ 2.  Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+ 3.  Neither the name of Electronic Arts, Inc. ("EA") nor the names of
+     its contributors may be used to endorse or promote products derived
+     from this software without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY ELECTRONIC ARTS AND ITS CONTRIBUTORS "AS IS" AND ANY
+ EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL ELECTRONIC ARTS OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package cloud.orbit.spring.actuate;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import cloud.orbit.actors.extensions.LifetimeExtension;
+import cloud.orbit.actors.runtime.AbstractActor;
+import cloud.orbit.concurrent.Task;
+
+import java.lang.ref.WeakReference;
+import java.util.concurrent.Executor;
+
+/**
+ * Provides hooks for an actor's activation and deactivation that are visited asynchronously, separate from the main
+ * lifecycle of the actor. Use this abstract class for expensive actor processing so that it does not block the
+ * activation and deactivation of an actor. Warning: Due to its asynchronous nature, there is no guarantee that the
+ * async hooks are called.
+ */
+public abstract class AsyncLifetimeExtension implements LifetimeExtension
+{
+    private static final Logger log = LoggerFactory.getLogger(AsyncLifetimeExtension.class);
+    private final Executor executor;
+
+    public AsyncLifetimeExtension(final Executor executor)
+    {
+        this.executor = executor;
+    }
+
+    @Override
+    public Task<?> postActivation(final AbstractActor<?> actor)
+    {
+        executor.execute(new AsyncJob(actor, true));
+        return Task.done();
+    }
+
+    @Override
+    public Task<?> postDeactivation(final AbstractActor<?> actor)
+    {
+        executor.execute(new AsyncJob(actor, false));
+        return Task.done();
+    }
+
+    protected abstract Task postActivationAsync(final AbstractActor<?> actor);
+
+    protected abstract Task postDeactivationAsync(final AbstractActor<?> actor);
+
+    private class AsyncJob implements Runnable {
+        private final WeakReference<AbstractActor<?>> actorReference;
+        private final boolean isActivation;
+
+        private AsyncJob(final AbstractActor<?> actor, final boolean isActivation)
+        {
+            this.actorReference = new WeakReference<>(actor);
+            this.isActivation = isActivation;
+        }
+
+        @Override
+        public void run()
+        {
+            AbstractActor<?> actor = actorReference.get();
+            if (actor == null)
+            {
+                log.debug("Lost reference to actor. Skipping background lifecycle handling.");
+            }
+            else
+            {
+                if (isActivation)
+                {
+                    postActivationAsync(actor).join();
+                }
+                else
+                {
+                    postDeactivationAsync(actor).join();
+                }
+            }
+        }
+    }
+}

--- a/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -5,6 +5,18 @@
       "description": "Enable ActorInfoContributorLifetimeExtension.",
       "type": "java.lang.Boolean",
       "defaultValue": true
+    },
+    {
+      "name": "management.info.actors.group.primary",
+      "description": "First-tier grouping strategy.",
+      "type": "cloud.orbit.spring.actuate.ActorInfoDetailsContainer$GroupProperties$GroupType",
+      "defaultValue": "interface"
+    },
+    {
+      "name": "management.info.actors.group.secondary",
+      "description": "Second-tier grouping strategy.",
+      "type": "cloud.orbit.spring.actuate.ActorInfoDetailsContainer$GroupProperties$GroupType",
+      "defaultValue": "identity"
     }
   ]
 }

--- a/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -1,0 +1,10 @@
+{
+  "properties": [
+    {
+      "name": "management.info.actors.enabled",
+      "description": "Enable ActorInfoContributorLifetimeExtension.",
+      "type": "java.lang.Boolean",
+      "defaultValue": true
+    }
+  ]
+}

--- a/src/test/java/cloud/orbit/spring/OrbitSpringConfigurationTest.java
+++ b/src/test/java/cloud/orbit/spring/OrbitSpringConfigurationTest.java
@@ -53,21 +53,21 @@ public class OrbitSpringConfigurationTest
     @Test(expected = IllegalArgumentException.class)
     public void buildStage_nullProperties_throws() throws Exception
     {
-        new OrbitSpringConfiguration().buildStage(null, null, null);
+        new OrbitSpringConfiguration().buildStage(null, null, null, null);
     }
 
     @Test
     public void buildStage_nullExtensionsAndNullMessagingAndNoProperties_ok() throws Exception
     {
-        new OrbitSpringConfiguration().buildStage(properties, null, null);
+        new OrbitSpringConfiguration().buildStage(properties, null, null, null);
     }
 
     @Test
     public void buildStage_withAnExtension_stageHasExtension() throws Exception
     {
         ActorExtension actorExtension = mock(ActorExtension.class);
-        Stage stage =
-                new OrbitSpringConfiguration().buildStage(properties, Collections.singletonList(actorExtension), null);
+        Stage stage = new OrbitSpringConfiguration()
+                .buildStage(properties, Collections.singletonList(actorExtension), null, null);
         assertThat(stage.getExtensions(), contains(actorExtension));
     }
 }

--- a/src/test/java/cloud/orbit/spring/actuate/ActorInfoContributorAutoConfigurationTest.java
+++ b/src/test/java/cloud/orbit/spring/actuate/ActorInfoContributorAutoConfigurationTest.java
@@ -1,0 +1,53 @@
+/*
+ Copyright (C) 2017 Electronic Arts Inc.  All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+
+ 1.  Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+ 2.  Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+ 3.  Neither the name of Electronic Arts, Inc. ("EA") nor the names of
+     its contributors may be used to endorse or promote products derived
+     from this software without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY ELECTRONIC ARTS AND ITS CONTRIBUTORS "AS IS" AND ANY
+ EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL ELECTRONIC ARTS OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package cloud.orbit.spring.actuate;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.NoSuchBeanDefinitionException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ApplicationContext;
+import org.springframework.test.context.junit4.SpringRunner;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE,
+        properties = "management.info.actors.enabled=false",
+        classes = ActorInfoContributorConfiguration.class)
+public class ActorInfoContributorAutoConfigurationTest
+{
+    @Autowired
+    private ApplicationContext applicationContext;
+
+    @Test(expected = NoSuchBeanDefinitionException.class)
+    public void extensionIsExplicitlyDisabled_extensionIsNotLoadedIntoContext() throws Exception
+    {
+        applicationContext.getBean(ActorInfoContributorLifetimeExtension.class);
+    }
+}

--- a/src/test/java/cloud/orbit/spring/actuate/ActorInfoContributorIntegrationTest.java
+++ b/src/test/java/cloud/orbit/spring/actuate/ActorInfoContributorIntegrationTest.java
@@ -1,0 +1,293 @@
+/*
+ Copyright (C) 2017 Electronic Arts Inc.  All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+
+ 1.  Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+ 2.  Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+ 3.  Neither the name of Electronic Arts, Inc. ("EA") nor the names of
+     its contributors may be used to endorse or promote products derived
+     from this software without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY ELECTRONIC ARTS AND ITS CONTRIBUTORS "AS IS" AND ANY
+ EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL ELECTRONIC ARTS OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package cloud.orbit.spring.actuate;
+
+import org.junit.After;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.actuate.autoconfigure.LocalManagementPort;
+import org.springframework.boot.actuate.info.Info;
+import org.springframework.boot.actuate.info.InfoContributor;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.web.client.RestTemplate;
+
+import com.google.common.collect.ImmutableMap;
+
+import cloud.orbit.actors.Actor;
+import cloud.orbit.actors.Stage;
+import cloud.orbit.actors.annotation.NoIdentity;
+import cloud.orbit.actors.annotation.StatelessWorker;
+import cloud.orbit.actors.runtime.AbstractActor;
+import cloud.orbit.concurrent.Task;
+import cloud.orbit.spring.OrbitBeanDefinitionRegistrar;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+        classes = OrbitBeanDefinitionRegistrar.class)
+@EnableAutoConfiguration
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
+public class ActorInfoContributorIntegrationTest
+{
+    @SuppressWarnings("unused")
+    @LocalManagementPort
+    private int port;
+
+    @Autowired
+    private Stage stage;
+
+    private Map<String, Object> result;
+
+    @After
+    public void tearDown() throws Exception
+    {
+        // The @DirtiesContext annotation doesn't take care of the stage, so we do it explicitly
+        stage.stop().join();
+    }
+
+    @Test
+    public void noActorInteraction_noInfo() throws Exception
+    {
+        readInfoEndpoint();
+        assertThat(result, equalTo(Collections.EMPTY_MAP));
+    }
+
+    @Test
+    public void activateBasicActor_hasInfo() throws Exception
+    {
+        Actor.getReference(ActorWithInjection.class, "0").setStat(10).join();
+        readInfoEndpoint();
+        assertThat(result.get("actors"), equalTo(ImmutableMap.of(
+                "ActorWithInjection", ImmutableMap.of(
+                        "0", ImmutableMap.of(
+                                "stat", 10,
+                                "constructorInjectedValue", 99,
+                                "fieldInjectedValue", 200)))));
+    }
+
+    @Test
+    public void activateActorWithNoIdentity_hasInfo() throws Exception
+    {
+        Actor.getReference(ActorNoIdentity.class).setStat(-10).join();
+        readInfoEndpoint();
+        assertThat(result.get("actors"), equalTo(ImmutableMap.of(
+                "ActorNoIdentity", ImmutableMap.of(
+                        "null", ImmutableMap.of(
+                                "stat", -10)))));
+    }
+
+    @Test
+    public void activateTwoActorsWithNoIdentity_hasInfoForLatestOneOnly() throws Exception
+    {
+        Actor.getReference(ActorNoIdentity.class).setStat(-10).join();
+        Actor.getReference(ActorNoIdentity.class).setStat(72).join();
+        readInfoEndpoint();
+        assertThat(result.get("actors"), equalTo(ImmutableMap.of(
+                "ActorNoIdentity", ImmutableMap.of(
+                        "null", ImmutableMap.of(
+                                "stat", 72)))));
+    }
+
+    @Test
+    public void activateStatelessWorker_hasInfo() throws Exception
+    {
+        Actor.getReference(FakeStatelessWorker.class, "foo").setStat(2).join();
+        readInfoEndpoint();
+        assertThat(result.get("actors"), equalTo(ImmutableMap.of(
+                "FakeStatelessWorker", ImmutableMap.of(
+                        "foo", ImmutableMap.of(
+                                "stat", 2)))));
+    }
+
+    @Test
+    public void activateManyActorsOfDifferentKinds_hasInfoForEverything() throws Exception
+    {
+        Actor.getReference(ActorWithInjection.class, "foo").setStat(2315).join();
+        Actor.getReference(ActorWithInjection.class, "bar").setStat(89).join();
+        Actor.getReference(ActorNoIdentity.class).setStat(99).join();
+        Actor.getReference(FakeStatelessWorker.class, "12").setStat(2).join();
+        Actor.getReference(FakeStatelessWorker.class, "biz").setStat(-14).join();
+        readInfoEndpoint();
+        assertThat(result.get("actors"), equalTo(ImmutableMap.of(
+                "ActorWithInjection", ImmutableMap.of(
+                        "foo", ImmutableMap.of(
+                                "stat", 2315,
+                                "constructorInjectedValue", 99,
+                                "fieldInjectedValue", 200),
+                        "bar", ImmutableMap.of(
+                                "stat", 89,
+                                "constructorInjectedValue", 99,
+                                "fieldInjectedValue", 200)
+                ),
+                "ActorNoIdentity", ImmutableMap.of(
+                        "null", ImmutableMap.of(
+                                "stat", 99)
+                ),
+                "FakeStatelessWorker", ImmutableMap.of(
+                        "12", ImmutableMap.of(
+                                "stat", 2),
+                        "biz", ImmutableMap.of(
+                                "stat", -14)
+                ))));
+    }
+
+    @Test
+    public void actorActivationTriggersAnotherActorActivation_noThreadLockAndBothContributeActorInfo() throws Exception
+    {
+        Actor.getReference(ActorWithCustomActivation.class, "jerry").setStat(101).join();
+        readInfoEndpoint();
+        assertThat(result.get("actors"), equalTo(ImmutableMap.of(
+                "ActorWithInjection", ImmutableMap.of(
+                        "indiana", ImmutableMap.of(
+                                "stat", 75,
+                                "constructorInjectedValue", 99,
+                                "fieldInjectedValue", 200)
+                ),
+                "ActorWithCustomActivation", ImmutableMap.of(
+                        "jerry", ImmutableMap.of(
+                                "stat", 101)
+                ))));
+    }
+
+    private void readInfoEndpoint()
+    {
+        //noinspection unchecked
+        result = new RestTemplate().getForObject(String.format("http://localhost:%d/info", port), LinkedHashMap.class);
+    }
+
+    @TestConfiguration
+    public static class ConfigurationUsedToVerifyInjectionStillWorks
+    {
+        @Bean
+        public int constructorInjectedValue()
+        {
+            return 99;
+        }
+
+        @Bean
+        public int fieldInjectedValue()
+        {
+            return 200;
+        }
+    }
+
+    private interface ActorWithStat
+    {
+        Task<Void> setStat(int stat);
+    }
+
+    private static class ActorWithStatImpl extends AbstractActor implements ActorWithStat, InfoContributor
+    {
+        private int stat;
+
+        @Override
+        public Task<Void> setStat(final int stat)
+        {
+            this.stat = stat;
+            return Task.done();
+        }
+
+        @Override
+        public void contribute(final Info.Builder builder)
+        {
+            builder.withDetail("stat", this.stat);
+        }
+    }
+
+    public interface ActorWithInjection extends ActorWithStat, Actor
+    {
+    }
+
+    public static class ActorWithInjectionImpl extends ActorWithStatImpl implements ActorWithInjection
+    {
+        private final int constructorInjectedValue;
+
+        @SuppressWarnings("SpringJavaAutowiredMembersInspection")
+        @Autowired
+        private int fieldInjectedValue;
+
+        public ActorWithInjectionImpl(final int constructorInjectedValue)
+        {
+            this.constructorInjectedValue = constructorInjectedValue;
+        }
+
+        @Override
+        public void contribute(final Info.Builder builder)
+        {
+            builder.withDetail("constructorInjectedValue", constructorInjectedValue)
+                    .withDetail("fieldInjectedValue", fieldInjectedValue);
+            super.contribute(builder);
+        }
+    }
+
+    @NoIdentity
+    public interface ActorNoIdentity extends ActorWithStat, Actor
+    {
+    }
+
+    public static class ActorNoIdentityImpl extends ActorWithStatImpl implements ActorNoIdentity
+    {
+    }
+
+    @StatelessWorker
+    public interface FakeStatelessWorker extends ActorWithStat, Actor
+    {
+    }
+
+    public static class FakeStatelessWorkerImpl extends ActorWithStatImpl implements FakeStatelessWorker
+    {
+    }
+
+    public interface ActorWithCustomActivation extends ActorWithStat, Actor
+    {
+    }
+
+    public static class ActorWithCustomActivationImpl extends ActorWithStatImpl implements ActorWithCustomActivation
+    {
+        @Override
+        public Task<?> activateAsync()
+        {
+            // activate an actor that implements InfoContributor to test that we don't thread lock
+            Actor.getReference(ActorWithInjection.class, "indiana").setStat(75).join();
+            return super.activateAsync();
+        }
+    }
+}

--- a/src/test/java/cloud/orbit/spring/actuate/ActorInfoContributorTest.java
+++ b/src/test/java/cloud/orbit/spring/actuate/ActorInfoContributorTest.java
@@ -1,0 +1,259 @@
+/*
+ Copyright (C) 2017 Electronic Arts Inc.  All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+
+ 1.  Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+ 2.  Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+ 3.  Neither the name of Electronic Arts, Inc. ("EA") nor the names of
+     its contributors may be used to endorse or promote products derived
+     from this software without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY ELECTRONIC ARTS AND ITS CONTRIBUTORS "AS IS" AND ANY
+ EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL ELECTRONIC ARTS OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package cloud.orbit.spring.actuate;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.boot.actuate.info.Info;
+import org.springframework.boot.actuate.info.InfoContributor;
+
+import com.google.common.collect.ImmutableMap;
+
+import cloud.orbit.actors.Actor;
+import cloud.orbit.actors.runtime.AbstractActor;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+public class ActorInfoContributorTest
+{
+    private ActorInfoContributorLifetimeExtension extension;
+
+    @Before
+    public void setUp() throws Exception
+    {
+        extension = new ActorInfoContributorLifetimeExtension(reference ->
+        {
+            // Ideally this would be a mock, but since Mockito keeps references in memory to arguments passed
+            // to mocked methods, and some of these tests rely on actor instances being garbage collected, it's
+            // necessary to create the fake object manually like so.
+            Class<? extends AbstractActor> referenceClass = reference.getClass();
+            if (FakeActorImpl.class.isAssignableFrom(referenceClass))
+            {
+                return FakeActor.class;
+            }
+            else if (OtherFakeActorImpl.class.isAssignableFrom(referenceClass))
+            {
+                return OtherFakeActor.class;
+            }
+            return null;
+        });
+    }
+
+    private Map<String, Object> getInfo()
+    {
+        Info.Builder builder = new Info.Builder();
+        extension.contribute(builder);
+        return builder.build().getDetails();
+    }
+
+    @Test
+    public void nothingRegistered_emptyMap() throws Exception
+    {
+        assertThat(getInfo(), equalTo(Collections.EMPTY_MAP));
+    }
+
+    @Test
+    public void actorIsActive_getActorInfo_callsIntoActor() throws Exception
+    {
+        FakeActorImpl actor = spy(new FakeActorImpl("a", "b", "c"));
+        extension.preActivation(actor).join();
+        getInfo();
+        verify(actor).contribute(any());
+    }
+
+    @Test
+    public void twoActorsWithSameInterface_separatedByIdentity() throws Exception
+    {
+        FakeActorImpl fakeActorA = new FakeActorImpl("123", "baz", 8);
+        FakeActorImpl fakeActorB = new FakeActorImpl("456", "biz", "goo");
+        extension.preActivation(fakeActorA).join();
+        extension.preActivation(fakeActorB).join();
+        assertThat(getInfo().get("actors"), equalTo(ImmutableMap.of(
+                "FakeActor", ImmutableMap.of(
+                        "123", ImmutableMap.of(
+                                "baz", 8),
+                        "456", ImmutableMap.of(
+                                "biz", "goo")))));
+    }
+
+    @Test
+    public void twoActorsWithDifferentInterfaces_separatedByInterface() throws Exception
+    {
+        FakeActorImpl fakeActorA = new FakeActorImpl("123", "something", 100);
+        OtherFakeActorImpl fakeActorB = new OtherFakeActorImpl("456", "number", 999);
+        extension.preActivation(fakeActorA).join();
+        extension.preActivation(fakeActorB).join();
+        assertThat(getInfo().get("actors"), equalTo(ImmutableMap.of(
+                "FakeActor", ImmutableMap.of(
+                        "123", ImmutableMap.of(
+                                "something", 100)),
+                "OtherFakeActor", ImmutableMap.of(
+                        "456", ImmutableMap.of(
+                                "number", 999)))));
+    }
+
+    @Test
+    public void actorGoesOffline_getsRemovedFromInfo() throws Exception
+    {
+        extension.preActivation(new FakeActorImpl("a", "b", "c")).join();
+        System.gc();
+        assertThat(getInfo(), equalTo(Collections.EMPTY_MAP));
+    }
+
+    @Test
+    public void testThreadSafe() throws Exception
+    {
+        Exception[] exceptionFromThread = new Exception[1];
+        Runnable runnable = () ->
+        {
+            List<Integer> indices = IntStream.range(0, 30).boxed().collect(Collectors.toList());
+            Collections.shuffle(indices);
+            String[] randomStrings = new String[]{"foo", "bar", "fiz", "buz", "panama"};
+            Random r = new Random();
+            try
+            {
+                for (int i : indices)
+                {
+                    if (r.nextBoolean())
+                    {
+                        extension.preActivation(new FakeActorImpl(String.valueOf(i),
+                                randomStrings[r.nextInt(randomStrings.length)],
+                                randomStrings[r.nextInt(randomStrings.length)])).join();
+                    }
+                    else
+                    {
+                        getInfo();
+                    }
+                }
+            }
+            catch (Exception e)
+            {
+                exceptionFromThread[0] = e;
+            }
+        };
+        Thread[] threads = new Thread[10];
+        for (int i = 0; i < threads.length; i++)
+        {
+            threads[i] = new Thread(runnable);
+        }
+        for (final Thread thread : threads)
+        {
+            thread.start();
+        }
+        for (final Thread thread : threads)
+        {
+            thread.join();
+        }
+        assertNull(exceptionFromThread[0]);
+    }
+
+    @Test
+    public void actorDoesNotImplementInfoContributor_actorDoesNotGetProcessed() throws Exception
+    {
+        NonInfoContributorFakeActor actor = new NonInfoContributorFakeActor();
+        extension.preActivation(actor).join();
+        assertThat(getInfo(), equalTo(Collections.EMPTY_MAP));
+    }
+
+    private interface FakeActor extends Actor
+    {
+    }
+
+    private static class FakeActorImpl extends AbstractActor implements FakeActor, InfoContributor
+    {
+        private final String identity;
+        private final String key;
+        private final Object value;
+
+        private FakeActorImpl(final String identity, final String key, final Object value)
+        {
+            this.identity = identity;
+            this.key = key;
+            this.value = value;
+        }
+
+        @Override
+        public String getIdentity()
+        {
+            return identity;
+        }
+
+        @Override
+        public void contribute(final Info.Builder builder)
+        {
+            builder.withDetail(key, value);
+        }
+    }
+
+    private static class NonInfoContributorFakeActor extends AbstractActor implements FakeActor
+    {
+    }
+
+    private interface OtherFakeActor extends Actor
+    {
+    }
+
+    private static class OtherFakeActorImpl extends AbstractActor implements OtherFakeActor, InfoContributor
+    {
+        private final String identity;
+        private final String key;
+        private final Object value;
+
+        private OtherFakeActorImpl(final String identity, final String key, final Object value)
+        {
+            this.identity = identity;
+            this.key = key;
+            this.value = value;
+        }
+
+        @Override
+        public String getIdentity()
+        {
+            return identity;
+        }
+
+        @Override
+        public void contribute(final Info.Builder builder)
+        {
+            builder.withDetail(key, value);
+        }
+    }
+}

--- a/src/test/java/cloud/orbit/spring/actuate/ActorInfoContributorTest.java
+++ b/src/test/java/cloud/orbit/spring/actuate/ActorInfoContributorTest.java
@@ -68,14 +68,16 @@ public class ActorInfoContributorTest
     public void setUp() throws Exception
     {
         initializeExtensionWithProperties(
-                ActorInfoDetailsContainer.GroupProperties.GroupType.INTERFACE,
-                ActorInfoDetailsContainer.GroupProperties.GroupType.IDENTITY);
+                ActorInfoContributorConfiguration.GroupProperties.GroupType.INTERFACE,
+                ActorInfoContributorConfiguration.GroupProperties.GroupType.IDENTITY);
     }
 
-    private void initializeExtensionWithProperties(final ActorInfoDetailsContainer.GroupProperties.GroupType primary,
-                                                   final ActorInfoDetailsContainer.GroupProperties.GroupType secondary)
+    private void initializeExtensionWithProperties(
+            final ActorInfoContributorConfiguration.GroupProperties.GroupType primary,
+            final ActorInfoContributorConfiguration.GroupProperties.GroupType secondary)
     {
-        ActorInfoDetailsContainer.GroupProperties groupProperties = new ActorInfoDetailsContainer.GroupProperties();
+        ActorInfoContributorConfiguration.GroupProperties groupProperties =
+                new ActorInfoContributorConfiguration.GroupProperties();
         groupProperties.setPrimary(primary);
         groupProperties.setSecondary(secondary);
         extension = new ActorInfoContributorLifetimeExtension(reference ->
@@ -224,8 +226,8 @@ public class ActorInfoContributorTest
     public void noGrouping_infoIsNotGrouped() throws Exception
     {
         initializeExtensionWithProperties(
-                ActorInfoDetailsContainer.GroupProperties.GroupType.NONE,
-                ActorInfoDetailsContainer.GroupProperties.GroupType.NONE);
+                ActorInfoContributorConfiguration.GroupProperties.GroupType.NONE,
+                ActorInfoContributorConfiguration.GroupProperties.GroupType.NONE);
         activateMixtureOfActors();
         Map actorInfo = (Map) getInfo().get("actors");
         assertThat(actorInfo.keySet(), equalTo(ImmutableSet.of("a", "b")));
@@ -236,8 +238,8 @@ public class ActorInfoContributorTest
     public void groupByPrimaryIdentity_infoIsGroupedByIdentity() throws Exception
     {
         initializeExtensionWithProperties(
-                ActorInfoDetailsContainer.GroupProperties.GroupType.IDENTITY,
-                ActorInfoDetailsContainer.GroupProperties.GroupType.NONE);
+                ActorInfoContributorConfiguration.GroupProperties.GroupType.IDENTITY,
+                ActorInfoContributorConfiguration.GroupProperties.GroupType.NONE);
         activateMixtureOfActors();
         assertThat(getInfo().get("actors"), equalTo(ImmutableMap.of(
                 "0", ImmutableMap.of(
@@ -252,8 +254,8 @@ public class ActorInfoContributorTest
     public void groupByPrimaryInterface_infoIsGroupedByInterface() throws Exception
     {
         initializeExtensionWithProperties(
-                ActorInfoDetailsContainer.GroupProperties.GroupType.INTERFACE,
-                ActorInfoDetailsContainer.GroupProperties.GroupType.NONE);
+                ActorInfoContributorConfiguration.GroupProperties.GroupType.INTERFACE,
+                ActorInfoContributorConfiguration.GroupProperties.GroupType.NONE);
         activateMixtureOfActors();
         assertThat(getInfo().get("actors"), equalTo(ImmutableMap.of(
                 "FakeActor", ImmutableMap.of(
@@ -268,8 +270,8 @@ public class ActorInfoContributorTest
     public void groupByPrimaryIdentitySecondaryInterface_infoIsGroupedByIdentityThenInterface() throws Exception
     {
         initializeExtensionWithProperties(
-                ActorInfoDetailsContainer.GroupProperties.GroupType.IDENTITY,
-                ActorInfoDetailsContainer.GroupProperties.GroupType.INTERFACE);
+                ActorInfoContributorConfiguration.GroupProperties.GroupType.IDENTITY,
+                ActorInfoContributorConfiguration.GroupProperties.GroupType.INTERFACE);
         activateMixtureOfActors();
         assertThat(getInfo().get("actors"), equalTo(ImmutableMap.of(
                 "0", ImmutableMap.of(


### PR DESCRIPTION
New auto-configured extension that only activates if Spring Boot Actuator is found in the classpath.

`ActorInfoContributorLifetimeExtension` allows users to plug actors into the `/info` management endpoint just like you would with any other Spring Bean.

Example:
```java
public class MyActorImpl extends AbstractActor implements MyActor, InfoContributor {
    @Override
    public void contribute(final Info.Builder builder) {
        builder.withDetail("status", state().getStatus());
    }
    ...
}
```
Then visiting http://localhost/info returns
```json
{
  "actors": {
    "MyActor": {
      "12345": {
        "status": {
          "foo": false,
          "bar": 0
        }
      }
    }
  }
}
```
...where `12345` is the actor identity, and status is a DTO with fields `foo` and `bar`.