### PR TITLE
Upgrade to orbit 1.0.0-rc3. 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
     </scm>
 
     <properties>
-        <orbit.version>1.0.0-rc1</orbit.version>
+        <orbit.version>1.0.0-rc3</orbit.version>
         <springboot.version>1.4.2.RELEASE</springboot.version>
     </properties>
 

--- a/src/main/java/cloud/orbit/spring/OrbitSpringConfiguration.java
+++ b/src/main/java/cloud/orbit/spring/OrbitSpringConfiguration.java
@@ -49,9 +49,9 @@ public class OrbitSpringConfiguration
     private List<OrbitSpringConfigurationAddon> configAddons;
 
     @Bean
-    public ActorExtension springLifecycleExtension(AutowireCapableBeanFactory factory)
+    public ActorExtension springActorConstructionExtension(AutowireCapableBeanFactory factory)
     {
-        return new SpringLifetimeExtension(factory);
+        return new SpringActorConstructionExtension(factory);
     }
 
     @Bean
@@ -107,13 +107,12 @@ public class OrbitSpringConfiguration
             stageBuilder.deactivationTimeout(properties.getDeactivationTimeoutInMilliseconds(), TimeUnit.MILLISECONDS);
         }
 
-        Stage stage = stageBuilder.build();
-
-        // TODO: Replace this with the version in StageBuilder once it lands in Orbit 1.0.0-rc3
         if (properties.getExecutionPoolSize() != null)
         {
-            stage.setExecutionPoolSize(properties.getExecutionPoolSize());
+            stageBuilder.executionPoolSize(properties.getExecutionPoolSize());
         }
+
+        Stage stage = stageBuilder.build();
 
         if (configAddons != null)
         {

--- a/src/main/java/cloud/orbit/spring/SpringActorConstructionExtension.java
+++ b/src/main/java/cloud/orbit/spring/SpringActorConstructionExtension.java
@@ -30,15 +30,13 @@ package cloud.orbit.spring;
 
 import org.springframework.beans.factory.config.AutowireCapableBeanFactory;
 
-import cloud.orbit.actors.extensions.LifetimeExtension;
-import cloud.orbit.actors.runtime.AbstractActor;
-import cloud.orbit.concurrent.Task;
+import cloud.orbit.actors.extensions.ActorConstructionExtension;
 
-class SpringLifetimeExtension implements LifetimeExtension
+class SpringActorConstructionExtension implements ActorConstructionExtension
 {
     private final AutowireCapableBeanFactory beanFactory;
 
-    public SpringLifetimeExtension(AutowireCapableBeanFactory beanFactory)
+    public SpringActorConstructionExtension(AutowireCapableBeanFactory beanFactory)
     {
         this.beanFactory = beanFactory;
     }
@@ -48,13 +46,5 @@ class SpringLifetimeExtension implements LifetimeExtension
     public <T> T newInstance(Class<T> concreteClass)
     {
         return beanFactory.createBean(concreteClass);
-    }
-
-    // Provides property injection for actors
-    @Override
-    public Task<Void> preActivation(AbstractActor<?> actor)
-    {
-        beanFactory.autowireBeanProperties(actor, AutowireCapableBeanFactory.AUTOWIRE_BY_TYPE, false);
-        return Task.done();
     }
 }

--- a/src/test/java/cloud/orbit/spring/OrbitSpringConfigurationTest.java
+++ b/src/test/java/cloud/orbit/spring/OrbitSpringConfigurationTest.java
@@ -46,7 +46,7 @@ import java.util.Map;
 import static org.junit.Assert.assertTrue;
 
 /*
- * Very simple (poor) tests to validate that the SpringLifecycleExtension is being properly bound to the Stage
+ * Very simple (poor) tests to validate that the SpringActorConstructionExtension is being properly bound to the Stage
  */
 @RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = WebEnvironment.NONE)
@@ -57,19 +57,17 @@ public class OrbitSpringConfigurationTest
     private ApplicationContext applicationContext;
 
     @Test
-    public void loadSpringLifecycleExtensions() throws Exception
+    public void loadSpringActorConsstructionExtension() throws Exception
     {
         Map<String, ActorExtension> actorExtensionBeans = applicationContext.getBeansOfType(ActorExtension.class);
-        assertTrue(actorExtensionBeans.keySet().contains("springLifecycleExtension"));
+        assertTrue(actorExtensionBeans.keySet().contains("springActorConstructionExtension"));
     }
 
     @Test
-    public void validateStageHasSpringLifecycleExtension() throws Exception
+    public void validateStageHasSpringActorConstructionExtension() throws Exception
     {
         Stage stage = applicationContext.getBean(Stage.class);
         List<ActorExtension> actorExtensions = stage.getAllExtensions(ActorExtension.class);
-        long count = actorExtensions.stream().filter(actorExtension -> actorExtension.getClass()
-                .isAssignableFrom(SpringLifetimeExtension.class)).count();
-        assertTrue(count == 1);
+        assertTrue(actorExtensions.stream().anyMatch((p -> p instanceof SpringActorConstructionExtension)));
     }
 }


### PR DESCRIPTION
Upgrades Orbit to 1.0.0-rc3.
This allows us to use the stage builder for executionPoolSize and allows us to use the new extension type and address #7.