### PR TITLE
Spring beans for commonly used Orbit static methods and singletons

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,48 @@ Orbit Spring Integration
 
 Integration for using the Spring Framework to manage an Orbit Cluster.
 
+## Orbit Dependency Injection Improvements
+
+With Orbit Spring, commonly accessed static methods in traditional Orbit are wrapped in service beans.
+This makes classes easier to test.
+
+__Traditional Orbit:__
+
+```java
+public class GuestbookHandler
+{
+    public Task addEntry(String bookId, EntryDto entry)
+    {
+        Guestbook guestbook = Actor.getReference(Guestbook.class, bookId);
+        return guestbook.addEntry(entry);
+    }
+}
+```
+
+__With Orbit Spring:__
+
+```java
+public class GuestbookHandler
+{
+    @Autowired
+    private ActorReferenceService actorReferenceService;
+    
+    public Task addEntry(String bookId, EntryDto entry)
+    {
+        Guestbook guestbook = actorReferenceService.getReference(Guestbook.class, bookId);
+        return guestbook.addEntry(entry);
+    }
+}
+```
+
+Here is a full list of service mappings for improved dependency injection:
+
+Traditional Orbit | Orbit Spring
+--- | ---
+Actor | ActorReferenceService
+RemoteReference | RemoteReferenceService
+AsyncStream | AsyncStreamService
+
 ## Actuator Support
 
 Orbit Spring provides autoconfigured contributors to the 

--- a/src/main/java/cloud/orbit/spring/service/ActorReferenceService.java
+++ b/src/main/java/cloud/orbit/spring/service/ActorReferenceService.java
@@ -1,0 +1,57 @@
+/*
+ Copyright (C) 2017 Electronic Arts Inc.  All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+
+ 1.  Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+ 2.  Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+ 3.  Neither the name of Electronic Arts, Inc. ("EA") nor the names of
+     its contributors may be used to endorse or promote products derived
+     from this software without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY ELECTRONIC ARTS AND ITS CONTRIBUTORS "AS IS" AND ANY
+ EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL ELECTRONIC ARTS OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package cloud.orbit.spring.service;
+
+import cloud.orbit.actors.Actor;
+
+/**
+ * Wraps static methods on the {@link Actor} interface
+ */
+public class ActorReferenceService
+{
+    public <T extends Actor> T getReference(Class<T> actorInterface, String id)
+    {
+        return Actor.getReference(actorInterface, id);
+    }
+
+    public <T extends Actor> T getReference(Class<T> actorInterface)
+    {
+        return Actor.getReference(actorInterface);
+    }
+
+    public String getIdentity(Actor actor)
+    {
+        return Actor.getIdentity(actor);
+    }
+
+    public <T> T cast(Class<T> remoteInterface, Actor actor)
+    {
+        return Actor.cast(remoteInterface, actor);
+    }
+}

--- a/src/main/java/cloud/orbit/spring/service/AsyncStreamService.java
+++ b/src/main/java/cloud/orbit/spring/service/AsyncStreamService.java
@@ -1,0 +1,47 @@
+/*
+ Copyright (C) 2017 Electronic Arts Inc.  All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+
+ 1.  Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+ 2.  Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+ 3.  Neither the name of Electronic Arts, Inc. ("EA") nor the names of
+     its contributors may be used to endorse or promote products derived
+     from this software without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY ELECTRONIC ARTS AND ITS CONTRIBUTORS "AS IS" AND ANY
+ EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL ELECTRONIC ARTS OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package cloud.orbit.spring.service;
+
+import cloud.orbit.actors.streams.AsyncStream;
+
+/**
+ * Wraps static methods on the {@link AsyncStream} interface
+ */
+public class AsyncStreamService
+{
+    public <T> AsyncStream<T> getStream(Class<T> dataClass, String id)
+    {
+        return AsyncStream.getStream(dataClass, id);
+    }
+
+    public <T> AsyncStream<T> getStream(Class<T> dataClass, String provider, String streamId)
+    {
+        return AsyncStream.getStream(dataClass, provider, streamId);
+    }
+}

--- a/src/main/java/cloud/orbit/spring/service/OrbitServiceConfiguration.java
+++ b/src/main/java/cloud/orbit/spring/service/OrbitServiceConfiguration.java
@@ -1,0 +1,61 @@
+/*
+ Copyright (C) 2017 Electronic Arts Inc.  All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+
+ 1.  Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+ 2.  Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+ 3.  Neither the name of Electronic Arts, Inc. ("EA") nor the names of
+     its contributors may be used to endorse or promote products derived
+     from this software without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY ELECTRONIC ARTS AND ITS CONTRIBUTORS "AS IS" AND ANY
+ EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL ELECTRONIC ARTS OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package cloud.orbit.spring.service;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Register commonly used static helpers in Orbit as Spring beans
+ */
+@Configuration
+public class OrbitServiceConfiguration
+{
+    @Bean
+    @ConditionalOnMissingBean(ActorReferenceService.class)
+    public ActorReferenceService actorReferenceService()
+    {
+        return new ActorReferenceService();
+    }
+
+    @Bean
+    @ConditionalOnMissingBean(RemoteReferenceService.class)
+    public RemoteReferenceService remoteReferenceService()
+    {
+        return new RemoteReferenceService();
+    }
+
+    @Bean
+    @ConditionalOnMissingBean(AsyncStreamService.class)
+    public AsyncStreamService asyncStreamService()
+    {
+        return new AsyncStreamService();
+    }
+}

--- a/src/main/java/cloud/orbit/spring/service/RemoteReferenceService.java
+++ b/src/main/java/cloud/orbit/spring/service/RemoteReferenceService.java
@@ -1,0 +1,96 @@
+/*
+ Copyright (C) 2017 Electronic Arts Inc.  All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+
+ 1.  Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+ 2.  Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+ 3.  Neither the name of Electronic Arts, Inc. ("EA") nor the names of
+     its contributors may be used to endorse or promote products derived
+     from this software without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY ELECTRONIC ARTS AND ITS CONTRIBUTORS "AS IS" AND ANY
+ EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL ELECTRONIC ARTS OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package cloud.orbit.spring.service;
+
+import cloud.orbit.actors.Actor;
+import cloud.orbit.actors.cluster.NodeAddress;
+import cloud.orbit.actors.runtime.AbstractActor;
+import cloud.orbit.actors.runtime.BasicRuntime;
+import cloud.orbit.actors.runtime.RemoteReference;
+
+/**
+ * Wraps static methods on the {@link RemoteReference} interface
+ */
+public class RemoteReferenceService
+{
+    public int getInterfaceId(RemoteReference<?> reference)
+    {
+        return RemoteReference.getInterfaceId(reference);
+    }
+
+    public Object getId(RemoteReference<?> reference)
+    {
+        return RemoteReference.getId(reference);
+    }
+
+    public Object getId(AbstractActor actor)
+    {
+        return RemoteReference.getId(actor);
+    }
+
+    public <R> Class<R> getInterfaceClass(RemoteReference<R> reference)
+    {
+        return RemoteReference.getInterfaceClass(reference);
+    }
+
+    public <R> Class<R> getInterfaceClass(AbstractActor reference)
+    {
+        return RemoteReference.getInterfaceClass(reference);
+    }
+
+    public NodeAddress getAddress(RemoteReference<?> reference)
+    {
+        return RemoteReference.getAddress(reference);
+    }
+
+    public void setAddress(RemoteReference<?> reference, NodeAddress nodeAddress)
+    {
+        RemoteReference.setAddress(reference, nodeAddress);
+    }
+
+    public RemoteReference from(AbstractActor actor)
+    {
+        return RemoteReference.from(actor);
+    }
+
+    public RemoteReference from(Actor actor)
+    {
+        return RemoteReference.from(actor);
+    }
+
+    public void setRuntime(RemoteReference<?> reference, BasicRuntime runtime)
+    {
+        RemoteReference.setRuntime(reference, runtime);
+    }
+
+    public BasicRuntime getRuntime(RemoteReference<?> original)
+    {
+        return RemoteReference.getRuntime(original);
+    }
+}

--- a/src/test/java/cloud/orbit/spring/service/OrbitServiceConfigurationIntegrationTest.java
+++ b/src/test/java/cloud/orbit/spring/service/OrbitServiceConfigurationIntegrationTest.java
@@ -1,0 +1,73 @@
+/*
+ Copyright (C) 2017 Electronic Arts Inc.  All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+
+ 1.  Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+ 2.  Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+ 3.  Neither the name of Electronic Arts, Inc. ("EA") nor the names of
+     its contributors may be used to endorse or promote products derived
+     from this software without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY ELECTRONIC ARTS AND ITS CONTRIBUTORS "AS IS" AND ANY
+ EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL ELECTRONIC ARTS OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package cloud.orbit.spring.service;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import cloud.orbit.actors.Actor;
+import cloud.orbit.actors.runtime.AbstractActor;
+import cloud.orbit.concurrent.Task;
+import cloud.orbit.spring.OrbitBeanDefinitionRegistrar;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE, classes = OrbitBeanDefinitionRegistrar.class)
+@EnableAutoConfiguration
+public class OrbitServiceConfigurationIntegrationTest
+{
+    @Autowired
+    private ActorReferenceService actorReferenceService;
+
+    @Test
+    public void testActorReferenceServiceGetsActorReference() throws Exception
+    {
+        assertThat(actorReferenceService.getReference(MyActor.class, "0").sayHello().join(), is("Hello"));
+    }
+
+    public interface MyActor extends Actor
+    {
+        Task<String> sayHello();
+    }
+
+    public static class MyActorImpl extends AbstractActor implements MyActor
+    {
+        @Override
+        public Task<String> sayHello()
+        {
+            return Task.fromValue("Hello");
+        }
+    }
+}


### PR DESCRIPTION
This pull request wraps some commonly used static utility methods from Orbit into Spring beans. This makes developers' code easier to get under tests.

__Traditional Orbit:__

```java
public class GuestbookHandler
{
    public Task addEntry(String bookId, EntryDto entry)
    {
        Guestbook guestbook = Actor.getReference(Guestbook.class, bookId);
        return guestbook.addEntry(entry);
    }
}
```

__With Orbit Spring:__

```java
public class GuestbookHandler
{
    @Autowired
    private ActorReferenceService actorReferenceService;
    
    public Task addEntry(String bookId, EntryDto entry)
    {
        Guestbook guestbook = actorReferenceService.getReference(Guestbook.class, bookId);
        return guestbook.addEntry(entry);
    }
}
```

Traditional Orbit | Orbit Spring
--- | ---
Actor | ActorReferenceService
RemoteReference | RemoteReferenceService
AsyncStream | AsyncStreamService