### PR TITLE
Auto-configured FakeClusterPeer for tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -98,9 +98,10 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-web</artifactId>
-            <scope>test</scope>
+            <groupId>cloud.orbit</groupId>
+            <artifactId>orbit-actor-tests</artifactId>
+            <version>${orbit.version}</version>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/src/main/java/cloud/orbit/spring/test/OrbitSpringTestConfiguration.java
+++ b/src/main/java/cloud/orbit/spring/test/OrbitSpringTestConfiguration.java
@@ -1,0 +1,53 @@
+/*
+ Copyright (C) 2017 Electronic Arts Inc.  All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+
+ 1.  Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+ 2.  Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+ 3.  Neither the name of Electronic Arts, Inc. ("EA") nor the names of
+     its contributors may be used to endorse or promote products derived
+     from this software without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY ELECTRONIC ARTS AND ITS CONTRIBUTORS "AS IS" AND ANY
+ EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL ELECTRONIC ARTS OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package cloud.orbit.spring.test;
+
+import org.springframework.boot.autoconfigure.AutoConfigureBefore;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import cloud.orbit.actors.cluster.ClusterPeer;
+import cloud.orbit.actors.test.FakeClusterPeer;
+import cloud.orbit.spring.OrbitSpringConfiguration;
+
+@Configuration
+@ConditionalOnClass(FakeClusterPeer.class)
+@ConditionalOnProperty("org.springframework.boot.test.context.SpringBootTestContextBootstrapper")
+@AutoConfigureBefore(OrbitSpringConfiguration.class)
+public class OrbitSpringTestConfiguration
+{
+    @Bean
+    @ConditionalOnMissingBean(ClusterPeer.class)
+    public ClusterPeer clusterPeer() {
+        return new FakeClusterPeer();
+    }
+}

--- a/src/main/java/cloud/orbit/spring/test/OrbitSpringTestConfigurationChecker.java
+++ b/src/main/java/cloud/orbit/spring/test/OrbitSpringTestConfigurationChecker.java
@@ -1,0 +1,57 @@
+/*
+ Copyright (C) 2017 Electronic Arts Inc.  All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+
+ 1.  Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+ 2.  Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+ 3.  Neither the name of Electronic Arts, Inc. ("EA") nor the names of
+     its contributors may be used to endorse or promote products derived
+     from this software without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY ELECTRONIC ARTS AND ITS CONTRIBUTORS "AS IS" AND ANY
+ EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL ELECTRONIC ARTS OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package cloud.orbit.spring.test;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Configuration;
+
+import cloud.orbit.actors.cluster.ClusterPeer;
+import cloud.orbit.spring.OrbitSpringConfiguration;
+
+@Configuration
+@ConditionalOnProperty("org.springframework.boot.test.context.SpringBootTestContextBootstrapper")
+@ConditionalOnMissingBean(ClusterPeer.class)
+@AutoConfigureAfter(OrbitSpringTestConfiguration.class)
+public class OrbitSpringTestConfigurationChecker implements InitializingBean
+{
+    private static final Logger log = LoggerFactory.getLogger(OrbitSpringConfiguration.class);
+
+    @Override
+    public void afterPropertiesSet() throws Exception
+    {
+        log.warn("Running tests without using a fake ClusterPeer is bad for performance. Consider adding a test "
+                + "dependency on orbit-actor-tests, or otherwise adding cloud.orbit.actors.test.FakeClusterPeer to "
+                + "your classpath.");
+    }
+}

--- a/src/test/java/cloud/orbit/spring/test/OrbitSpringTestConfigurationIntegrationTest.java
+++ b/src/test/java/cloud/orbit/spring/test/OrbitSpringTestConfigurationIntegrationTest.java
@@ -1,0 +1,56 @@
+/*
+ Copyright (C) 2017 Electronic Arts Inc.  All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+
+ 1.  Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+ 2.  Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+ 3.  Neither the name of Electronic Arts, Inc. ("EA") nor the names of
+     its contributors may be used to endorse or promote products derived
+     from this software without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY ELECTRONIC ARTS AND ITS CONTRIBUTORS "AS IS" AND ANY
+ EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL ELECTRONIC ARTS OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package cloud.orbit.spring.test;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import cloud.orbit.actors.Stage;
+import cloud.orbit.actors.test.FakeClusterPeer;
+import cloud.orbit.spring.OrbitBeanDefinitionRegistrar;
+
+import static org.junit.Assert.assertTrue;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE,
+        classes = OrbitBeanDefinitionRegistrar.class)
+public class OrbitSpringTestConfigurationIntegrationTest
+{
+    @Autowired
+    Stage stage;
+
+    @Test
+    public void testsAutoLoadFakeClusterPeer() throws Exception
+    {
+        assertTrue(stage.getClusterPeer() instanceof FakeClusterPeer);
+    }
+}


### PR DESCRIPTION
Adds a new FakeClusterPeer bean that gets auto-loaded if the `org.springframework.boot.test.context.SpringBootTestContextBootstrapper` property is enabled. This property gets enabled when tests are run using the `SpringRunner`, so effectively you have a bean that is only enabled in Spring integration tests.

Logs a warning if the user is running a test without orbit-actor-tests