### PR TITLE
Add configuration setting to enable/disable autostarting of Stage

### DIFF
--- a/src/main/java/cloud/orbit/spring/OrbitActorsProperties.java
+++ b/src/main/java/cloud/orbit/spring/OrbitActorsProperties.java
@@ -50,6 +50,7 @@ public class OrbitActorsProperties
     private Long localAddressCacheTTLInMilliseconds;
     private Integer localAddressCacheMaximumSize;
     private Boolean broadcastActorDeactivations;
+    private Boolean autostartStage = Boolean.TRUE;
 
 
     public List<String> getBasePackages()
@@ -180,5 +181,15 @@ public class OrbitActorsProperties
     public void setBroadcastActorDeactivations(Boolean broadcastActorDeactivations)
     {
         this.broadcastActorDeactivations = broadcastActorDeactivations;
+    }
+
+    public Boolean getAutostartStage()
+    {
+        return autostartStage;
+    }
+
+    public void setAutostartStage(Boolean autostartStage)
+    {
+        this.autostartStage = autostartStage;
     }
 }

--- a/src/main/java/cloud/orbit/spring/OrbitSpringConfiguration.java
+++ b/src/main/java/cloud/orbit/spring/OrbitSpringConfiguration.java
@@ -132,8 +132,11 @@ public class OrbitSpringConfiguration
             configAddons.forEach(addon -> addon.configure(stage));
         }
 
-        stage.start().join();
-        stage.bind();
+        if (properties.getAutostartStage())
+        {
+            stage.start().join();
+            stage.bind();
+        }
 
         return stage;
     }


### PR DESCRIPTION
Add configuration setting to enable/disable autostarting  Stage. 

`orbit.actors.autostartStage: {true|false}`

By default the stage is started when the bean is created. 